### PR TITLE
Update probe to not use deprecated pkt_pts_time

### DIFF
--- a/src/ffmpeg_smart_trim/trim.py
+++ b/src/ffmpeg_smart_trim/trim.py
@@ -9,7 +9,7 @@ import ffmpeg
 
 class TrimVideo:
     def __init__(self, video_path, temp_dir=None, time_range: (Decimal, Decimal) = None):
-        probe = ffmpeg.probe(video_path, skip_frame="nokey", show_entries="frame=pkt_pts_time", select_streams="v:0")
+        probe = ffmpeg.probe(video_path, skip_frame="nokey", show_entries="frame=pts_time", select_streams="v:0")
         self.vcodec = ffmpeg.probe(video_path, select_streams="v:0")['streams'][0]['codec_name']
         self.acodec = ffmpeg.probe(video_path, select_streams="a:0")['streams'][0]['codec_name']
         self.key_frame_timestamps = [Decimal(frame['pkt_pts_time']) for frame in probe['frames']]

--- a/src/ffmpeg_smart_trim/trim.py
+++ b/src/ffmpeg_smart_trim/trim.py
@@ -12,7 +12,7 @@ class TrimVideo:
         probe = ffmpeg.probe(video_path, skip_frame="nokey", show_entries="frame=pts_time", select_streams="v:0")
         self.vcodec = ffmpeg.probe(video_path, select_streams="v:0")['streams'][0]['codec_name']
         self.acodec = ffmpeg.probe(video_path, select_streams="a:0")['streams'][0]['codec_name']
-        self.key_frame_timestamps = [Decimal(frame['pkt_pts_time']) for frame in probe['frames']]
+        self.key_frame_timestamps = [Decimal(frame['pts_time']) for frame in probe['frames']]
         self.duration = Decimal(probe['streams'][0]['duration'])
         self.video_path = video_path
         if time_range is None:


### PR DESCRIPTION
pkt_pts_time was renamed as pts_time and pkt_pts_time was deprecated/removed from ffmpeg/ffprobe.

> field has been deprecated in 32c8359093d1ff4f45ed19518b449b3ac3769d27 and removed in 6e30b35b85b81c802e52a1078ec7a3097e353c6d. 44d5e12c8faa1c170ed9b6b0c9e18c7547572144 therefore renamed what ffprobe reported to just "pts" and "pts_time". Notice that the values reported as pkt_pts and pkt_pts_time were already based upon the AVFrame's pts field (whose value agreed with pkt_pts -- this was the reason why pkt_pts was deprecated and remove).
So just use pts_time instead of pkt_pts_time.

https://trac.ffmpeg.org/ticket/9543